### PR TITLE
Fixes #158 - Added single additional export of uuidv4

### DIFF
--- a/lib/uuidv4.ts
+++ b/lib/uuidv4.ts
@@ -27,6 +27,7 @@ const fromString = function (text: string): string {
 
 export {
   uuidv4 as uuid,
+  uuidv4,
   regex,
   isUuid,
   empty,


### PR DESCRIPTION
This makes the module easier to use as a drop in replacement without creating naming conflicts with existing variables named `uuid`.