### PR TITLE
modify isUuid method to maintain the exact same legacy pre-V8.3.0 behaviour

### DIFF
--- a/lib/uuidv4.ts
+++ b/lib/uuidv4.ts
@@ -19,7 +19,7 @@ const uuidv4 = deprecate(
 );
 
 const isUuid = deprecate(
-  (value: string): boolean => {return validate(value) && (version(value) === 4 || version(value) === 5)},
+  (value: string): boolean => validate(value) && (version(value) === 4 || version(value) === 5),
   'isUuid() is deprecated. Use validate() from the uuid module instead.'
 );
 

--- a/lib/uuidv4.ts
+++ b/lib/uuidv4.ts
@@ -1,5 +1,5 @@
 import { deprecate } from 'util';
-import { NIL as nil, v4, v5, validate } from 'uuid';
+import { NIL as nil, v4, v5, validate, version } from 'uuid';
 
 const regex = {
   v4: /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u,
@@ -19,7 +19,7 @@ const uuidv4 = deprecate(
 );
 
 const isUuid = deprecate(
-  (value: string): boolean => validate(value),
+  (value: string): boolean => {return validate(value) && (version(value) === 4 || version(value) === 5)},
   'isUuid() is deprecated. Use validate() from the uuid module instead.'
 );
 

--- a/test/unit/uuidv4Tests.ts
+++ b/test/unit/uuidv4Tests.ts
@@ -70,6 +70,14 @@ suite('uuid', (): void => {
     test('returns false if no UUID v4 or v5 is given.', async (): Promise<void> => {
       assert.that(isUuid('definitely-not-a-uuid')).is.false();
     });
+
+    test('returns false if a UUID v1 is given.', async (): Promise<void> => {
+      assert.that(isUuid('d9428888-122b-11e1-b85c-61cd3cbb3210')).is.false();
+    });
+
+    test('returns false if a UUID v3 is given.', async (): Promise<void> => {
+      assert.that(isUuid('a981a0c2-68b1-35dc-bcfc-296e52ab01ec')).is.false();
+    });
   });
 
   suite('fromString', (): void => {

--- a/test/unit/uuidv4Tests.ts
+++ b/test/unit/uuidv4Tests.ts
@@ -63,8 +63,8 @@ suite('uuid', (): void => {
       assert.that(isUuid('cdb63720-9628-5ef6-bbca-2e5ce6094f3c')).is.true();
     });
 
-    test('returns true if an empty UUID is given.', async (): Promise<void> => {
-      assert.that(isUuid('00000000-0000-0000-0000-000000000000')).is.true();
+    test('returns false if an empty UUID is given.', async (): Promise<void> => {
+      assert.that(isUuid('00000000-0000-0000-0000-000000000000')).is.false();
     });
 
     test('returns false if no UUID v4 or v5 is given.', async (): Promise<void> => {


### PR DESCRIPTION
This is still using [uuidjs/uuid]( https://github.com/uuidjs/uuid)
I have also added corresponded tests.